### PR TITLE
Carps and Tables Take 2

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -7,6 +7,8 @@
 	icon_living = "carp"
 	icon_dead = "carp_dead"
 	icon_gib = "carp_gib"
+	flags = TABLEPASS
+	pass_flags = PASSTABLE
 	speak_chance = 0
 	turns_per_move = 5
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/carpmeat


### PR DESCRIPTION
Allows Carp to pass through tables with 100% certainty this time. This is the same code used for aliens, monkeys, meteors, etc. so if this doesn't work, god help me.  

The reason TABLEPASS does not work is because it was removed from the defines sometime in late 2013, making only PASSTABLE valid. Still, leaving in for legacy's sake, because god damn bitmasks.
